### PR TITLE
Ignored availability_set_id for Windows VM

### DIFF
--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -185,7 +185,7 @@ resource "azurerm_windows_virtual_machine" "vm" {
 
   lifecycle {
     ignore_changes = [
-      resource_group_name, location, os_disk[0].name
+      resource_group_name, location, os_disk[0].name, availability_set_id
     ]
   }
 


### PR DESCRIPTION
When adding a new availability set, previous deployed VM's are getting destroyed and recreated.